### PR TITLE
Fixed issue #42 - Open social media icons to new tab

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -90,8 +90,8 @@ export const Footer: React.FC<ComponentProps> = ({
           <List>
             {icons.map(function (icon) {
               return (
-                <ListItem key={icon.id} target="_blank">
-                  <Link href={`${icon.path}`}>{icon.icon}</Link>
+                <ListItem key={icon.id}>
+                  <Link href={`${icon.path}`}  target="_blank">{icon.icon}</Link>
                 </ListItem>
               )
             })}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -90,7 +90,7 @@ export const Footer: React.FC<ComponentProps> = ({
           <List>
             {icons.map(function (icon) {
               return (
-                <ListItem key={icon.id}>
+                <ListItem key={icon.id} target="_blank">
                   <Link href={`${icon.path}`}>{icon.icon}</Link>
                 </ListItem>
               )


### PR DESCRIPTION
The social media icons now open the link in a new tab.